### PR TITLE
403 arn reference change in s3 policy due to access denial

### DIFF
--- a/modules/aws-s3-static-website/main.tf
+++ b/modules/aws-s3-static-website/main.tf
@@ -60,8 +60,11 @@ resource "aws_s3_bucket_policy" "web" {
         Principal = "*"
         Action    = "s3:GetObject"
         Resource = [
-          aws_s3_bucket.web.arn,
+          "${aws_s3_bucket.web.arn}",
           "${aws_s3_bucket.web.arn}/*",
+        # Resource = [
+        #   aws_s3_bucket.web.arn,
+        #   "${aws_s3_bucket.web.arn}/*",
         ]
       },
     ]

--- a/modules/aws-s3-static-website/main.tf
+++ b/modules/aws-s3-static-website/main.tf
@@ -62,9 +62,6 @@ resource "aws_s3_bucket_policy" "web" {
         Resource = [
           "${aws_s3_bucket.web.arn}",
           "${aws_s3_bucket.web.arn}/*",
-        # Resource = [
-        #   aws_s3_bucket.web.arn,
-        #   "${aws_s3_bucket.web.arn}/*",
         ]
       },
     ]


### PR DESCRIPTION
I changed the reference to the part where 403 access denied occurs in the s3 policy of module/main.tf.